### PR TITLE
fix: download the Electron binary on install

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -33,11 +33,6 @@ jobs:
       - name: Install dependencies
         run: npm ci
 
-      # npm ci does not run electron's postinstall on the runners, so the
-      # dist binary the tests spawn is missing; install.js is idempotent.
-      - name: Download Electron binary
-        run: node node_modules/electron/install.js
-
       - name: Typecheck
         run: npm run typecheck
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -7,6 +7,7 @@
     "": {
       "name": "pix",
       "version": "0.0.11",
+      "hasInstallScript": true,
       "dependencies": {
         "@earendil-works/pi-ai": "0.85.0",
         "@earendil-works/pi-coding-agent": "0.85.0",

--- a/package.json
+++ b/package.json
@@ -35,7 +35,8 @@
     "test:packaged": "node test/packaged-smoke-test.mjs",
     "test:fff": "node test/builtin-fff-smoke-test.mjs",
     "test:web": "node --test test/bundle-pi-package.test.mjs && node test/builtin-web-smoke-test.mjs",
-    "dev": "electron-vite dev"
+    "dev": "electron-vite dev",
+    "postinstall": "node node_modules/electron/install.js"
   },
   "dependencies": {
     "@earendil-works/pi-ai": "0.85.0",


### PR DESCRIPTION
## Problem

A clean clone cannot start the app:

```
npm ci       # succeeds
npm run dev  # Error: Electron uninstall
```

`electron@44.1.1` ships no lifecycle scripts. Electron 42 removed the package's own `postinstall`, so nothing downloads `node_modules/electron/dist` any more:

```
$ npm view electron@41.0.0 scripts
{ postinstall: 'node install.js' }

$ npm view electron@44.1.1 scripts
(empty)
```

Electron's replacement lazy download does not cover this path either: `electron-vite` never requires `electron`, it reads `path.txt` directly and throws when the file is missing (`getElectronPath()`), so the download is never triggered.

`build.yml` already worked around this with an explicit step. Its comment attributes the missing binary to `npm ci` not running Electron's postinstall on the runners; there is no Electron postinstall in either environment, so the step is now redundant.

## Change

- `package.json`: run the same command as the root `postinstall`, so both `npm install` and `npm ci` provision the binary.
- `build.yml`: remove the redundant step.
- `package-lock.json`: the `hasInstallScript` line npm writes for a package with install scripts.

This matches Electron's release notes: *"Build pipelines, test runners, or container builds that previously relied on `npm install` to pre-fetch the Electron binary will need to explicitly run `npx install-electron` or `npx electron` before running tasks that require the binary."*

## Verification

Clean clone, before and after the patch (Node 24.15, macOS arm64):

| | before | after |
| --- | --- | --- |
| `npm ci` | succeeds | succeeds |
| `node_modules/electron/path.txt` | missing | present (44.1.1) |
| `npm run dev` | `Error: Electron uninstall` | `starting electron app...`, window opens |
| `node test/electron-pty-test.mjs`, after `npm ci` alone | Electron fails to launch | `Electron PTY passed` |

Repeat installs stay offline. `install.js` returns before downloading when the binary already matches the package:

```js
if (isInstalled()) {
  process.exit(0);
}
```

Two consecutive runs on an installed tree finish in 0.06s and 0.03s, against roughly 300s for a network download.

## Behaviour changes

- `npm install --omit=dev` now fails with `Cannot find module .../electron/install.js`, because `electron` is a devDependency. No script in this repo runs without devDependencies, so that install was not usable before either; `--ignore-scripts` skips the step.
- A failed download now fails `npm install` directly instead of surfacing later as an opaque `Electron uninstall` at `npm run dev`.
